### PR TITLE
NP-1979: checking for empty values in depth

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -285,19 +285,8 @@
       <property name="target"
         value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
-    <module name="JavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
-    </module>
-    <module name="MissingJavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test, ParameterizedTest"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
-    </module>
+
+
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -35,11 +35,19 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
         this.emptyFields = new ArrayList<>();
     }
 
-    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues() {
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringClasses() {
         return new DoesNotHaveEmptyValues<>();
     }
 
-    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues(List<Class<?>> ignoreList) {
+    /**
+     * Stop the nested check for the classes in the ignore list. The fields of the specified types will be checked
+     * whether they are null or not, but their fields will not be checked.
+     *
+     * @param ignoreList List of classes where the nested field check will stop.
+     * @param <R>        the type of the object in test.
+     * @return a matcher.
+     */
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringClasses(List<Class<?>> ignoreList) {
         DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
         ArrayList<Class<?>> newIgnoreList = new ArrayList<>();
         newIgnoreList.addAll(matcher.ignoreList);

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -19,11 +19,11 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     public static final String TEST_DESCRIPTION = "All fields of all included objects need to be non empty";
 
     private final List<PropertyValuePair>  emptyFields;
-    private List<Class<?>> ignoreList;
+    private List<Class<?>> stopRecursionClasses;
 
     public DoesNotHaveEmptyValues() {
         super();
-        ignoreList = doNotCheckRecursively();
+        stopRecursionClasses = doNotCheckRecursively();
 
         this.emptyFields = new ArrayList<>();
     }
@@ -42,16 +42,15 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
      */
     public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringClasses(List<Class<?>> ignoreList) {
         DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
-        ArrayList<Class<?>> newIgnoreList = new ArrayList<>();
-        newIgnoreList.addAll(matcher.ignoreList);
-        newIgnoreList.addAll(ignoreList);
-        matcher.ignoreList = newIgnoreList;
+        ArrayList<Class<?>> newStopRecursionClasses = new ArrayList<>();
+        newStopRecursionClasses.addAll(matcher.stopRecursionClasses);
+        newStopRecursionClasses.addAll(ignoreList);
+        matcher.stopRecursionClasses = newStopRecursionClasses;
         return matcher;
     }
 
     @Override
     public boolean matches(Object actual) {
-
         return check(PropertyValuePair.rootObject(actual));
     }
 
@@ -81,18 +80,7 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     }
 
     private List<Class<?>> doNotCheckRecursively() {
-        return List.of(
-            String.class,
-            Integer.class,
-            Double.class,
-            Float.class,
-            Boolean.class,
-            Map.class,
-            Collection.class,
-            JsonNode.class,
-            Class.class,
-            URI.class
-        );
+        return List.of(URI.class);
     }
 
     private void checkRecursivelyForEmptyFields(PropertyValuePair propValue) {
@@ -103,8 +91,8 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
     private boolean shouldNotBeIgnored(Object value) {
         return
-            ignoreList.stream()
-                .noneMatch(ignoredClass -> ignoredClass.isInstance(value));
+            stopRecursionClasses.stream()
+                .noneMatch(stopRecursionClass -> stopRecursionClass.isInstance(value));
     }
 
     private List<PropertyValuePair> collectEmptyFields(List<PropertyValuePair> propertyValuePairs) {

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -99,8 +99,8 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     }
 
     private boolean shouldNotBeIgnored(Object value) {
-        return
-            stopRecursionClasses.stream()
+        return stopRecursionClasses
+                .stream()
                 .noneMatch(stopRecursionClass -> stopRecursionClass.isInstance(value));
     }
 
@@ -123,32 +123,28 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
     private boolean isEmptyMap(Object value) {
         if (value instanceof Map) {
-            Map<?, ?> coll = (Map<?, ?>) value;
-            return coll.isEmpty();
+            return ((Map<?, ?>) value).isEmpty();
         }
         return false;
     }
 
     private boolean isEmptyJsonNode(Object value) {
         if (value instanceof JsonNode) {
-            JsonNode node = (JsonNode) value;
-            return node.isEmpty();
+            return ((JsonNode) value).isEmpty();
         }
         return false;
     }
 
     private boolean isEmptyCollection(Object value) {
         if (value instanceof Collection) {
-            Collection<?> coll = (Collection<?>) value;
-            return coll.isEmpty();
+            return ((Collection<?>) value).isEmpty();
         }
         return false;
     }
 
     private boolean isBlankString(Object value) {
         if (value instanceof String) {
-            String strValue = (String) value;
-            return strValue.isBlank();
+            return ((String) value).isBlank();
         }
         return false;
     }

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -26,26 +26,26 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     public static final String TEST_DESCRIPTION = "All fields of all included objects need to be non empty";
 
     private final List<PropertyValuePair> emptyFields;
-    private final List<Class> ignoreList = List.of(
-        String.class,
-        Integer.class,
-        Double.class,
-        Float.class,
-        Boolean.class,
-        Map.class,
-        Collection.class,
-        JsonNode.class,
-        Class.class,
-        URI.class
-    );
+    private List<Class<?>> ignoreList;
 
     public DoesNotHaveEmptyValues() {
         super();
+        ignoreList = doNotCheckRecursively();
+
         this.emptyFields = new ArrayList<>();
     }
 
     public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues() {
         return new DoesNotHaveEmptyValues<>();
+    }
+
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues(List<Class<?>> ignoreList) {
+        DoesNotHaveEmptyValues<R> matcher = new DoesNotHaveEmptyValues<>();
+        ArrayList<Class<?>> newIgnoreList = new ArrayList<>();
+        newIgnoreList.addAll(matcher.ignoreList);
+        newIgnoreList.addAll(ignoreList);
+        matcher.ignoreList = newIgnoreList;
+        return matcher;
     }
 
     @Override
@@ -78,6 +78,21 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
         description.appendText(EMPTY_FIELD_ERROR)
             .appendText(emptyFieldNames);
+    }
+
+    private List<Class<?>> doNotCheckRecursively() {
+        return List.of(
+            String.class,
+            Integer.class,
+            Double.class,
+            Float.class,
+            Boolean.class,
+            Map.class,
+            Collection.class,
+            JsonNode.class,
+            Class.class,
+            URI.class
+        );
     }
 
     private void checkRecursivelyForEmptyFields(String fieldPath, PropertyValuePair propValue) {
@@ -153,8 +168,6 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
             || isEmptyMap(value)
             || isEmptyJsonNode(value);
     }
-
-
 
     private boolean isEmptyMap(Object value) {
         if (value instanceof Map) {

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -35,7 +35,7 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
         this.emptyFields = new ArrayList<>();
     }
 
-    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValuesIgnoringClasses() {
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues() {
         return new DoesNotHaveEmptyValues<>();
     }
 

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -3,6 +3,7 @@ package no.unit.nva.hamcrest;
 import static java.util.Objects.isNull;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -22,7 +23,7 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
     public DoesNotHaveEmptyValues() {
         super();
-        stopRecursionClasses = doNotCheckRecursively();
+        stopRecursionClasses = classesWithNoPojoStructure();
 
         this.emptyFields = new ArrayList<>();
     }
@@ -78,8 +79,12 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
             .appendText(emptyFieldNames);
     }
 
-    private List<Class<?>> doNotCheckRecursively() {
-        return List.of(URI.class);
+    /*Classes that their fields do not have getters*/
+    private List<Class<?>> classesWithNoPojoStructure() {
+        return List.of(
+            URI.class,
+            URL.class
+        );
     }
 
     private void checkRecursivelyForEmptyFields(PropertyValuePair propValue) {

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -13,12 +13,11 @@ import org.hamcrest.Description;
 
 public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
 
-
     public static final String EMPTY_FIELD_ERROR = "Empty field found: ";
     public static final String FIELD_DELIMITER = ",";
     public static final String TEST_DESCRIPTION = "All fields of all included objects need to be non empty";
 
-    private final List<PropertyValuePair>  emptyFields;
+    private final List<PropertyValuePair> emptyFields;
     private List<Class<?>> stopRecursionClasses;
 
     public DoesNotHaveEmptyValues() {
@@ -84,6 +83,11 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
     }
 
     private void checkRecursivelyForEmptyFields(PropertyValuePair propValue) {
+        if (propValue.isCollection()) {
+            List<PropertyValuePair> collectionElements =
+                propValue.createPropertyValuePairsForEachCollectionItem();
+            collectionElements.forEach(this::check);
+        }
         if (propValue.isNotBaseType() && shouldNotBeIgnored(propValue.getValue())) {
             check(propValue);
         }
@@ -100,7 +104,6 @@ public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
             .filter(propertyValue -> isEmpty(propertyValue.getValue()))
             .collect(Collectors.toList());
     }
-
 
     private boolean isEmpty(Object value) {
         if (isNull(value)) {

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValues.java
@@ -1,0 +1,207 @@
+package no.unit.nva.hamcrest;
+
+import static java.util.Objects.isNull;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+public class DoesNotHaveEmptyValues<T> extends BaseMatcher<T> {
+
+    public static final String ERROR_INVOKING_GETTER = "Could not get value for method: ";
+    public static final String EMPTY_FIELD_ERROR = "Empty field found: ";
+    public static final String FIELD_DELIMITER = ",";
+    public static final String FIELD_PATH_DELIMITER = ".";
+    public static final String TEST_DESCRIPTION = "All fields of all included objects need to be non empty";
+
+    private final List<PropertyValuePair> emptyFields;
+
+    public DoesNotHaveEmptyValues() {
+        super();
+        this.emptyFields = new ArrayList<>();
+    }
+
+    public static <R> DoesNotHaveEmptyValues<R> doesNotHaveEmptyValues() {
+        return new DoesNotHaveEmptyValues<>();
+    }
+
+    @Override
+    public boolean matches(Object actual) {
+        return check(actual, "");
+    }
+
+    public boolean check(Object fieldValue, String fieldPath) {
+        List<PropertyDescriptor> properties = extractProperties(fieldValue);
+        List<PropertyValuePair> propertyValuePairs = constructPropertyValuePairs(fieldValue, properties);
+        for (PropertyValuePair propValue : propertyValuePairs) {
+            checkRecursivelyForEmptyFields(fieldPath, propValue);
+        }
+        List<PropertyValuePair> emptyValues = collectEmptyFields(propertyValuePairs, fieldPath);
+        emptyFields.addAll(emptyValues);
+        return emptyFields.isEmpty();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(TEST_DESCRIPTION);
+    }
+
+    @Override
+    public void describeMismatch(Object item, Description description) {
+        String emptyFieldNames = emptyFields.stream()
+            .map(PropertyValuePair::getFieldPath)
+            .collect(Collectors.joining(
+                FIELD_DELIMITER));
+
+        description.appendText(EMPTY_FIELD_ERROR)
+            .appendText(emptyFieldNames);
+    }
+
+    private void checkRecursivelyForEmptyFields(String fieldPath, PropertyValuePair propValue) {
+        if (isNotBaseType(propValue.getValue())) {
+            String valueFieldPath = updateFieldPath(fieldPath, propValue);
+            check(propValue.getValue(), valueFieldPath);
+        }
+    }
+
+    private List<PropertyValuePair> collectEmptyFields(List<PropertyValuePair> propertyValuePairs, String fieldPath) {
+        return propertyValuePairs.stream()
+            .filter(propertyValue -> isEmpty(propertyValue.getValue()))
+            .map(propertyValuePair -> propertyValuePair.updateFieldPath(fieldPath))
+            .collect(Collectors.toList());
+    }
+
+    private String updateFieldPath(String fieldPath, PropertyValuePair propValue) {
+        return fieldPath + FIELD_PATH_DELIMITER + propValue.getPropertyName();
+    }
+
+    private List<PropertyValuePair> constructPropertyValuePairs(Object fieldValue,
+                                                                List<PropertyDescriptor> properties) {
+        return properties.stream()
+            .map(getter -> extractFieldValues(fieldValue, getter))
+            .collect(Collectors.toList());
+    }
+
+    private List<PropertyDescriptor> extractProperties(Object fieldValue) {
+        BeanInfo beanInfo = getBeanInfo(fieldValue);
+        return Arrays.stream(beanInfo.getPropertyDescriptors())
+            .collect(Collectors.toList());
+    }
+
+    private boolean isNotBaseType(Object value) {
+        return !
+            (
+                isNull(value)
+                || value instanceof String
+                || value instanceof Integer
+                || value instanceof Double
+                || value instanceof Float
+                || value instanceof Boolean
+                || value instanceof Map
+                || value instanceof Collection
+                || value instanceof JsonNode
+                || value instanceof Class
+            );
+    }
+
+    private BeanInfo getBeanInfo(Object actual) {
+        try {
+            return Introspector.getBeanInfo(actual.getClass());
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isEmpty(Object value) {
+        if (isNull(value)) {
+            return true;
+        }
+        return
+            isBlankString(value)
+            || isEmptyCollection(value)
+            || isEmptyMap(value)
+            || isEmptyJsonNode(value);
+    }
+
+    private boolean isEmptyMap(Object value) {
+        if (value instanceof Map) {
+            Map<?, ?> coll = (Map<?, ?>) value;
+            return coll.isEmpty();
+        }
+        return false;
+    }
+
+    private boolean isEmptyJsonNode(Object value) {
+        if (value instanceof JsonNode) {
+            JsonNode node = (JsonNode) value;
+            return node.isEmpty();
+        }
+        return false;
+    }
+
+    private boolean isEmptyCollection(Object value) {
+        if (value instanceof Collection) {
+            Collection<?> coll = (Collection<?>) value;
+            return coll.isEmpty();
+        }
+        return false;
+    }
+
+    private boolean isBlankString(Object value) {
+        if (value instanceof String) {
+            String strValue = (String) value;
+            return strValue.isBlank();
+        }
+        return false;
+    }
+
+    private PropertyValuePair extractFieldValues(Object actual, PropertyDescriptor propertyDescriptor) {
+        try {
+            return new PropertyValuePair(
+                propertyDescriptor.getName(),
+                propertyDescriptor.getReadMethod().invoke(actual)
+            );
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(ERROR_INVOKING_GETTER + propertyDescriptor.getName(), e);
+        }
+    }
+
+    private static class PropertyValuePair {
+
+        private final String propertyName;
+        private final Object value;
+        private String fieldPath;
+
+        public PropertyValuePair(String propertyName, Object value) {
+            this.propertyName = propertyName;
+            this.value = value;
+        }
+
+        public String getPropertyName() {
+            return propertyName;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+
+        public String getFieldPath() {
+            return fieldPath;
+        }
+
+        public PropertyValuePair updateFieldPath(String parent) {
+            this.fieldPath = parent + FIELD_PATH_DELIMITER + propertyName;
+            return this;
+        }
+    }
+}

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
@@ -1,7 +1,6 @@
 package no.unit.nva.hamcrest;
 
 import static java.util.Objects.isNull;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -24,6 +23,12 @@ public class DoesNotHaveNullOrEmptyFields<T> extends BaseMatcher<T> {
 
     private List<PropertyValuePair> emptyFields;
 
+    /**
+     * use doesNotHaveEmptyValues instead.
+     * @param <R>
+     * @return
+     */
+    @Deprecated
     public static <R> DoesNotHaveNullOrEmptyFields<R> doesNotHaveNullOrEmptyFields() {
         return new DoesNotHaveNullOrEmptyFields<>();
     }

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
@@ -48,8 +48,7 @@ public class DoesNotHaveNullOrEmptyFields<T> extends BaseMatcher<T> {
     public void describeMismatch(Object item, Description description) {
         String emptyFieldNames = emptyFields.stream()
             .map(res -> res.propertyName)
-            .collect(Collectors.joining(
-                FIELD_DELIMITER));
+            .collect(Collectors.joining(FIELD_DELIMITER));
 
         description.appendText("The following fields were found empty:")
             .appendText(emptyFieldNames);

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
@@ -25,8 +25,9 @@ public class DoesNotHaveNullOrEmptyFields<T> extends BaseMatcher<T> {
 
     /**
      * use doesNotHaveEmptyValues instead.
-     * @param <R>
-     * @return
+     *
+     * @param <R> the type of the object
+     * @return a new matcher
      */
     @Deprecated
     public static <R> DoesNotHaveNullOrEmptyFields<R> doesNotHaveNullOrEmptyFields() {

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
@@ -21,7 +21,7 @@ public class DoesNotHaveNullOrEmptyFields<T> extends BaseMatcher<T> {
     public static final String FIELD_DELIMITER = ",";
     public static final String PROPERTY_READ_ERRROR = "Could not read value for property:";
 
-    private List<PropertyValuePair> emptyFields;
+    private  List<PropertyValuePair> emptyFields;
 
     /**
      * use doesNotHaveEmptyValues instead.

--- a/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
+++ b/src/main/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFields.java
@@ -24,7 +24,7 @@ public class DoesNotHaveNullOrEmptyFields<T> extends BaseMatcher<T> {
     private  List<PropertyValuePair> emptyFields;
 
     /**
-     * use doesNotHaveEmptyValues instead.
+     * use {@link DoesNotHaveEmptyValues#doesNotHaveEmptyValues} instead.
      *
      * @param <R> the type of the object
      * @return a new matcher

--- a/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
+++ b/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 public class PropertyValuePair {
 
-    public static final String ERROR_INVOKING_GETTER = "Could not get value for method: ";
+    public static final String ERROR_INVOKING_GETTER = "Could not get value for field: ";
     public static final String FIELD_PATH_DELIMITER = ".";
     public static final String ROOT_OBJECT_PATH = "";
     public static final String ARRAY_INDEX = ":";
@@ -140,7 +140,7 @@ public class PropertyValuePair {
                 this.fieldPath
             );
         } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(ERROR_INVOKING_GETTER + propertyDescriptor.getName(), e);
+            throw new RuntimeException(ERROR_INVOKING_GETTER + fieldPath, e);
         }
     }
 }

--- a/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
+++ b/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
@@ -21,7 +21,6 @@ public class PropertyValuePair {
     public static final String ERROR_INVOKING_GETTER = "Could not get value for field: ";
     public static final String FIELD_PATH_DELIMITER = ".";
     public static final String ROOT_OBJECT_PATH = "";
-    public static final String ARRAY_INDEX = ":";
     public static final String LEFT_BRACE = "[";
     public static final String RIGHT_BRACE = "]";
     private final String propertyName;
@@ -140,7 +139,8 @@ public class PropertyValuePair {
                 this.fieldPath
             );
         } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(ERROR_INVOKING_GETTER + fieldPath, e);
+            String fieldName = this.fieldPath + FIELD_PATH_DELIMITER +propertyDescriptor.getName();
+            throw new RuntimeException(ERROR_INVOKING_GETTER + fieldName, e);
         }
     }
 }

--- a/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
+++ b/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
@@ -1,0 +1,107 @@
+package no.unit.nva.hamcrest;
+
+import static java.util.Objects.isNull;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PropertyValuePair {
+
+    public static final String ERROR_INVOKING_GETTER = "Could not get value for method: ";
+    public static final String FIELD_PATH_DELIMITER = ".";
+    public static final String ROOT_OBJECT_PATH = "";
+    private final String propertyName;
+    private final Object value;
+    private final String fieldPath;
+
+    public PropertyValuePair(String propertyName, Object value, String parentPath) {
+        this.propertyName = propertyName;
+        this.value = value;
+
+        this.fieldPath = formatFieldPathInfo(propertyName, parentPath);
+    }
+
+    private String formatFieldPathInfo(String propertyName, String parentPath) {
+        if (isRootObject()) {
+            return ROOT_OBJECT_PATH;
+        } else {
+            return parentPath + FIELD_PATH_DELIMITER + propertyName;
+        }
+    }
+
+    private boolean isRootObject() {
+        return isNull(propertyName);
+    }
+
+    public static PropertyValuePair rootObject(Object object) {
+        return new PropertyValuePair(null, object, ROOT_OBJECT_PATH);
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public String getFieldPath() {
+        return fieldPath;
+    }
+
+    public List<PropertyValuePair> children() {
+        BeanInfo beanInfo = getBeanInfo(value);
+        List<PropertyDescriptor> properties = Arrays.stream(beanInfo.getPropertyDescriptors())
+            .collect(Collectors.toList());
+
+        List<PropertyValuePair> result = properties.stream()
+            .map(getter -> extractFieldValues(value, getter))
+            .collect(Collectors.toList());
+        return result;
+    }
+
+    private BeanInfo getBeanInfo(Object actual) {
+        try {
+            return Introspector.getBeanInfo(actual.getClass());
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PropertyValuePair extractFieldValues(Object actual, PropertyDescriptor propertyDescriptor) {
+        try {
+            return new PropertyValuePair(
+                propertyDescriptor.getName(),
+                propertyDescriptor.getReadMethod().invoke(actual),
+                this.fieldPath
+            );
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(ERROR_INVOKING_GETTER + propertyDescriptor.getName(), e);
+        }
+    }
+
+    public boolean isNotBaseType() {
+        return !
+            (
+                isNull(value)
+                || value.getClass().isPrimitive()
+                || value instanceof String
+                || value instanceof Integer
+                || value instanceof Double
+                || value instanceof Float
+                || value instanceof Boolean
+                || value instanceof Map
+                || value instanceof Collection
+                || value instanceof JsonNode
+                || value instanceof Class
+            );
+    }
+}

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -136,7 +136,7 @@ public class DoesNotHaveEmptyValuesTest {
     }
 
     @Test
-    public void matchesDoesNotCheckFieldInCustomlyAddedIgnoreClass() {
+    public void matchesDoesNotCheckFieldInAdditionalCustomIgnoreClass() {
         WithBaseTypes ignoredObjectWithEmptyProperties =
             new WithBaseTypes(null, null, null, null, null);
 

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,10 +82,6 @@ public class DoesNotHaveEmptyValuesTest {
         assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
     }
 
-    private WithPrimitiveFields objectMissingStringField() {
-        return new WithPrimitiveFields(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
-    }
-
     @Test
     public void matchesReturnsFalseWhenStringIsNull() {
         WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(null,
@@ -95,10 +92,20 @@ public class DoesNotHaveEmptyValuesTest {
         assertThat(matcher.matches(nonEmptyObject), is(false));
     }
 
+    @Test
+    public void matchesDoesNotCheckFieldsInIgnoredList() {
+        ClassWithUri withUri = new ClassWithUri(URI.create("http://example.com"));
+        assertThat(matcher.matches(withUri), is(true));
+    }
+
     private static JsonNode nonEmptyJsonNode() {
         ObjectNode node = new ObjectMapper().createObjectNode();
         node.put("someKey", "someValue");
         return node;
+    }
+
+    private WithPrimitiveFields objectMissingStringField() {
+        return new WithPrimitiveFields(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
     }
 
     private static class WithPrimitiveFields {
@@ -162,6 +169,19 @@ public class DoesNotHaveEmptyValuesTest {
 
         public Integer getSomeIntField() {
             return someIntField;
+        }
+    }
+
+    private static class ClassWithUri {
+
+        private final URI uri;
+
+        private ClassWithUri(URI uri) {
+            this.uri = uri;
+        }
+
+        public URI getUri() {
+            return uri;
         }
     }
 }

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -30,7 +30,7 @@ public class DoesNotHaveEmptyValuesTest {
     public static final String INT_FIELD = "intField";
     public static final String OBJECT_FIELD = "objectWithFields";
     public static final String STRING_FIELD = "stringField";
-    public static final URI EXAMPLE_URI = URI.create("http://example.com");
+    public static final URI EXAMPLE_URI = URI.create("http://example.org");
     public static final String LIST_FIELD = "listWithIncompleteEntries";
     private DoesNotHaveEmptyValues<Object> matcher;
 

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -2,7 +2,7 @@ package no.unit.nva.hamcrest;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.FIELD_PATH_DELIMITER;
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -61,7 +61,7 @@ public class DoesNotHaveEmptyValuesTest {
             SAMPLE_JSON_NODE);
 
         AssertionError exception = assertThrows(AssertionError.class,
-            () -> assertThat(withEmptyInt, doesNotHaveEmptyValues()));
+            () -> assertThat(withEmptyInt, doesNotHaveEmptyValuesIgnoringClasses()));
         assertThat(exception.getMessage(), containsString(EMPTY_FIELD_ERROR));
         assertThat(exception.getMessage(), containsString("intField"));
     }
@@ -78,7 +78,7 @@ public class DoesNotHaveEmptyValuesTest {
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
         AssertionError error = assertThrows(AssertionError.class,
-            () -> assertThat(testObject, doesNotHaveEmptyValues()));
+            () -> assertThat(testObject, doesNotHaveEmptyValuesIgnoringClasses()));
         assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
     }
 
@@ -135,7 +135,7 @@ public class DoesNotHaveEmptyValuesTest {
 
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, ignoredObjectWithEmptyProperties, SAMPLE_INT);
-        assertThat(testObject, doesNotHaveEmptyValues(List.of(WithBaseTypes.class)));
+        assertThat(testObject, doesNotHaveEmptyValuesIgnoringClasses(List.of(WithBaseTypes.class)));
     }
 
     private static JsonNode nonEmptyJsonNode() {

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -2,7 +2,6 @@ package no.unit.nva.hamcrest;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.FIELD_PATH_DELIMITER;
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -61,7 +60,7 @@ public class DoesNotHaveEmptyValuesTest {
             SAMPLE_JSON_NODE);
 
         AssertionError exception = assertThrows(AssertionError.class,
-            () -> assertThat(withEmptyInt, doesNotHaveEmptyValuesIgnoringClasses()));
+            () -> assertThat(withEmptyInt, DoesNotHaveEmptyValues.doesNotHaveEmptyValues()));
         assertThat(exception.getMessage(), containsString(EMPTY_FIELD_ERROR));
         assertThat(exception.getMessage(), containsString("intField"));
     }
@@ -78,7 +77,7 @@ public class DoesNotHaveEmptyValuesTest {
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
         AssertionError error = assertThrows(AssertionError.class,
-            () -> assertThat(testObject, doesNotHaveEmptyValuesIgnoringClasses()));
+            () -> assertThat(testObject, DoesNotHaveEmptyValues.doesNotHaveEmptyValues()));
         assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
     }
 

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -2,7 +2,7 @@ package no.unit.nva.hamcrest;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.FIELD_PATH_DELIMITER;
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -61,7 +61,7 @@ public class DoesNotHaveEmptyValuesTest {
             SAMPLE_JSON_NODE);
 
         AssertionError exception = assertThrows(AssertionError.class,
-            () -> assertThat(withEmptyInt, doesNotHaveEmptyValues()));
+            () -> assertThat(withEmptyInt, doesNotHaveEmptyValuesIgnoringClasses()));
         assertThat(exception.getMessage(), containsString(EMPTY_FIELD_ERROR));
         assertThat(exception.getMessage(), containsString("intField"));
     }
@@ -78,7 +78,7 @@ public class DoesNotHaveEmptyValuesTest {
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
         AssertionError error = assertThrows(AssertionError.class,
-            () -> assertThat(testObject, doesNotHaveEmptyValues()));
+            () -> assertThat(testObject, doesNotHaveEmptyValuesIgnoringClasses()));
         assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
     }
 
@@ -135,7 +135,7 @@ public class DoesNotHaveEmptyValuesTest {
 
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, ignoredObjectWithEmptyProperties, SAMPLE_INT);
-        assertThat(testObject, doesNotHaveEmptyValues(List.of(WithBaseTypes.class)));
+        assertThat(testObject, DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses(List.of(WithBaseTypes.class)));
     }
 
     private static JsonNode nonEmptyJsonNode() {

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -27,6 +27,11 @@ public class DoesNotHaveEmptyValuesTest {
     public static final int SAMPLE_INT = 16;
     public static final String EMPTY_STRING = "";
     private static final JsonNode SAMPLE_JSON_NODE = nonEmptyJsonNode();
+    public static final String INT_FIELD = "intField";
+    public static final String OBJECT_FIELD = "objectWithFields";
+    public static final String STRING_FIELD = "stringField";
+    public static final URI EXAMPLE_URI = URI.create("http://example.com");
+    public static final String LIST_FIELD = "listWithIncompleteEntries";
     private DoesNotHaveEmptyValues<Object> matcher;
 
     @BeforeEach
@@ -65,7 +70,7 @@ public class DoesNotHaveEmptyValuesTest {
         AssertionError exception = assertThrows(AssertionError.class,
             () -> assertThat(withEmptyInt, DoesNotHaveEmptyValues.doesNotHaveEmptyValues()));
         assertThat(exception.getMessage(), containsString(EMPTY_FIELD_ERROR));
-        assertThat(exception.getMessage(), containsString("intField"));
+        assertThat(exception.getMessage(), containsString(INT_FIELD));
     }
 
     @Test
@@ -81,7 +86,7 @@ public class DoesNotHaveEmptyValuesTest {
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
         AssertionError error = assertThrows(AssertionError.class,
             () -> assertThat(testObject, DoesNotHaveEmptyValues.doesNotHaveEmptyValues()));
-        assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
+        assertThat(error.getMessage(), containsString(OBJECT_FIELD + FIELD_PATH_DELIMITER + STRING_FIELD));
     }
 
     @Test
@@ -126,12 +131,12 @@ public class DoesNotHaveEmptyValuesTest {
 
     @Test
     public void matchesDoesNotCheckFieldsInIgnoredList() {
-        ClassWithUri withUri = new ClassWithUri(URI.create("http://example.com"));
+        ClassWithUri withUri = new ClassWithUri(EXAMPLE_URI);
         assertThat(matcher.matches(withUri), is(true));
     }
 
     @Test
-    public void matchesDoesNotCheckFieldInCustomlyAddedIngoreClass() {
+    public void matchesDoesNotCheckFieldInCustomlyAddedIgnoreClass() {
         WithBaseTypes ignoredObjectWithEmptyProperties =
             new WithBaseTypes(null, null, null, null, null);
 
@@ -147,7 +152,7 @@ public class DoesNotHaveEmptyValuesTest {
             new WithBaseTypes(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
         ClassWithList withList = new ClassWithList(List.of(objectWithSomeEmptyValue));
         AssertionError error = assertThrows(AssertionError.class, () -> assertThat(withList, doesNotHaveEmptyValues()));
-        String expectedFieldName = "listWithIncompleteEntries";
+        String expectedFieldName = LIST_FIELD;
         int expectedIndex = 0;
         assertThat(error.getMessage(), containsString(expectedFieldName));
         assertThat(error.getMessage(), containsString(LEFT_BRACE + expectedIndex + RIGHT_BRACE));
@@ -155,7 +160,7 @@ public class DoesNotHaveEmptyValuesTest {
 
     private static JsonNode nonEmptyJsonNode() {
         ObjectNode node = new ObjectMapper().createObjectNode();
-        node.put("someKey", "someValue");
+        node.put(SAMPLE_STRING, SAMPLE_STRING);
         return node;
     }
 

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -34,7 +34,7 @@ public class DoesNotHaveEmptyValuesTest {
 
     @Test
     public void matchesReturnsTrueWhenObjectWithSimpleFieldsHasNoNullValue() {
-        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(SAMPLE_STRING,
+        WithBaseTypes nonEmptyObject = new WithBaseTypes(SAMPLE_STRING,
             SAMPLE_INT,
             SAMPLE_LIST,
             SAMPLE_MAP,
@@ -44,7 +44,7 @@ public class DoesNotHaveEmptyValuesTest {
 
     @Test
     public void matchesReturnsFalseWhenStringIsEmpty() {
-        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(EMPTY_STRING,
+        WithBaseTypes nonEmptyObject = new WithBaseTypes(EMPTY_STRING,
             SAMPLE_INT,
             SAMPLE_LIST,
             SAMPLE_MAP,
@@ -54,7 +54,7 @@ public class DoesNotHaveEmptyValuesTest {
 
     @Test
     public void matcherReturnsMessageContainingTheFieldNameWhenFieldIsEmpty() {
-        WithPrimitiveFields withEmptyInt = new WithPrimitiveFields(SAMPLE_STRING,
+        WithBaseTypes withEmptyInt = new WithBaseTypes(SAMPLE_STRING,
             null,
             SAMPLE_LIST,
             SAMPLE_MAP,
@@ -83,13 +83,43 @@ public class DoesNotHaveEmptyValuesTest {
     }
 
     @Test
-    public void matchesReturnsFalseWhenStringIsNull() {
-        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(null,
+    public void matchesReturnsFalseWhenBaseTypeIsNull() {
+        WithBaseTypes baseTypesObject = new WithBaseTypes(null,
             SAMPLE_INT,
             SAMPLE_LIST,
             SAMPLE_MAP,
             SAMPLE_JSON_NODE);
-        assertThat(matcher.matches(nonEmptyObject), is(false));
+        assertThat(matcher.matches(baseTypesObject), is(false));
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenListIsEmpty() {
+        WithBaseTypes baseTypesObject = new WithBaseTypes(SAMPLE_STRING,
+            SAMPLE_INT,
+            Collections.emptyList(),
+            SAMPLE_MAP,
+            SAMPLE_JSON_NODE);
+        assertThat(matcher.matches(baseTypesObject), is(false));
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenMapIsEmpty() {
+        WithBaseTypes baseTypesObject = new WithBaseTypes(SAMPLE_STRING,
+            SAMPLE_INT,
+            SAMPLE_LIST,
+            Collections.emptyMap(),
+            SAMPLE_JSON_NODE);
+        assertThat(matcher.matches(baseTypesObject), is(false));
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenJsonNodeIsEmpty() {
+        WithBaseTypes baseTypesObject = new WithBaseTypes(SAMPLE_STRING,
+            SAMPLE_INT,
+            SAMPLE_LIST,
+            SAMPLE_MAP,
+            new ObjectMapper().createObjectNode());
+        assertThat(matcher.matches(baseTypesObject), is(false));
     }
 
     @Test
@@ -98,17 +128,27 @@ public class DoesNotHaveEmptyValuesTest {
         assertThat(matcher.matches(withUri), is(true));
     }
 
+    @Test
+    public void matchesDoesNotCheckFieldInCustomlyAddedIngoreClass() {
+        WithBaseTypes ignoredObjectWithEmptyProperties =
+            new WithBaseTypes(null, null, null, null, null);
+
+        ClassWithChildrenWithMultipleFields testObject =
+            new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, ignoredObjectWithEmptyProperties, SAMPLE_INT);
+        assertThat(testObject, doesNotHaveEmptyValues(List.of(WithBaseTypes.class)));
+    }
+
     private static JsonNode nonEmptyJsonNode() {
         ObjectNode node = new ObjectMapper().createObjectNode();
         node.put("someKey", "someValue");
         return node;
     }
 
-    private WithPrimitiveFields objectMissingStringField() {
-        return new WithPrimitiveFields(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
+    private WithBaseTypes objectMissingStringField() {
+        return new WithBaseTypes(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
     }
 
-    private static class WithPrimitiveFields {
+    private static class WithBaseTypes {
 
         private final String stringField;
         private final Integer intField;
@@ -116,8 +156,8 @@ public class DoesNotHaveEmptyValuesTest {
         private final Map<String, String> map;
         private final JsonNode jsonNode;
 
-        public WithPrimitiveFields(String stringField, Integer intField, List<String> list,
-                                   Map<String, String> map, JsonNode jsonNode) {
+        public WithBaseTypes(String stringField, Integer intField, List<String> list,
+                             Map<String, String> map, JsonNode jsonNode) {
             this.stringField = stringField;
             this.intField = intField;
             this.list = list;
@@ -149,11 +189,11 @@ public class DoesNotHaveEmptyValuesTest {
     private static class ClassWithChildrenWithMultipleFields {
 
         private final String someStringField;
-        private final WithPrimitiveFields objectWithFields;
+        private final WithBaseTypes objectWithFields;
         private final Integer someIntField;
 
         public ClassWithChildrenWithMultipleFields(String someStringField,
-                                                   WithPrimitiveFields objectWithFields, Integer someIntField) {
+                                                   WithBaseTypes objectWithFields, Integer someIntField) {
             this.someStringField = someStringField;
             this.objectWithFields = objectWithFields;
             this.someIntField = someIntField;
@@ -163,7 +203,7 @@ public class DoesNotHaveEmptyValuesTest {
             return someStringField;
         }
 
-        public WithPrimitiveFields getObjectWithFields() {
+        public WithBaseTypes getObjectWithFields() {
             return objectWithFields;
         }
 

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -1,7 +1,7 @@
 package no.unit.nva.hamcrest;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.FIELD_PATH_DELIMITER;
+import static no.unit.nva.hamcrest.PropertyValuePair.FIELD_PATH_DELIMITER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -1,7 +1,10 @@
 package no.unit.nva.hamcrest;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.hamcrest.PropertyValuePair.FIELD_PATH_DELIMITER;
+import static no.unit.nva.hamcrest.PropertyValuePair.LEFT_BRACE;
+import static no.unit.nva.hamcrest.PropertyValuePair.RIGHT_BRACE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -134,7 +137,20 @@ public class DoesNotHaveEmptyValuesTest {
 
         ClassWithChildrenWithMultipleFields testObject =
             new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, ignoredObjectWithEmptyProperties, SAMPLE_INT);
-        assertThat(testObject, DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses(List.of(WithBaseTypes.class)));
+        assertThat(testObject,
+            DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringClasses(List.of(WithBaseTypes.class)));
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenListElementHasEmptyValues() {
+        WithBaseTypes objectWithSomeEmptyValue =
+            new WithBaseTypes(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
+        ClassWithList withList = new ClassWithList(List.of(objectWithSomeEmptyValue));
+        AssertionError error = assertThrows(AssertionError.class, () -> assertThat(withList, doesNotHaveEmptyValues()));
+        String expectedFieldName = "listWithIncompleteEntries";
+        int expectedIndex = 0;
+        assertThat(error.getMessage(), containsString(expectedFieldName));
+        assertThat(error.getMessage(), containsString(LEFT_BRACE + expectedIndex + RIGHT_BRACE));
     }
 
     private static JsonNode nonEmptyJsonNode() {
@@ -221,6 +237,19 @@ public class DoesNotHaveEmptyValuesTest {
 
         public URI getUri() {
             return uri;
+        }
+    }
+
+    private static class ClassWithList {
+
+        private final List<WithBaseTypes> listWithIncompleteEntries;
+
+        public ClassWithList(List<WithBaseTypes> listWithIncompleteEntries) {
+            this.listWithIncompleteEntries = listWithIncompleteEntries;
+        }
+
+        public List<WithBaseTypes> getListWithIncompleteEntries() {
+            return listWithIncompleteEntries;
         }
     }
 }

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveEmptyValuesTest.java
@@ -1,0 +1,167 @@
+package no.unit.nva.hamcrest;
+
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.EMPTY_FIELD_ERROR;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.FIELD_PATH_DELIMITER;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DoesNotHaveEmptyValuesTest {
+
+    public static final String SAMPLE_STRING = "sampleString";
+    public static final Map<String, String> SAMPLE_MAP = Map.of(SAMPLE_STRING, SAMPLE_STRING);
+    public static final List<String> SAMPLE_LIST = Collections.singletonList(SAMPLE_STRING);
+    public static final int SAMPLE_INT = 16;
+    public static final String EMPTY_STRING = "";
+    private static final JsonNode SAMPLE_JSON_NODE = nonEmptyJsonNode();
+    private DoesNotHaveEmptyValues<Object> matcher;
+
+    @BeforeEach
+    public void init() {
+        matcher = new DoesNotHaveEmptyValues<>();
+    }
+
+    @Test
+    public void matchesReturnsTrueWhenObjectWithSimpleFieldsHasNoNullValue() {
+        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(SAMPLE_STRING,
+            SAMPLE_INT,
+            SAMPLE_LIST,
+            SAMPLE_MAP,
+            SAMPLE_JSON_NODE);
+        assertThat(matcher.matches(nonEmptyObject), is(true));
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenStringIsEmpty() {
+        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(EMPTY_STRING,
+            SAMPLE_INT,
+            SAMPLE_LIST,
+            SAMPLE_MAP,
+            SAMPLE_JSON_NODE);
+        assertThat(matcher.matches(nonEmptyObject), is(false));
+    }
+
+    @Test
+    public void matcherReturnsMessageContainingTheFieldNameWhenFieldIsEmpty() {
+        WithPrimitiveFields withEmptyInt = new WithPrimitiveFields(SAMPLE_STRING,
+            null,
+            SAMPLE_LIST,
+            SAMPLE_MAP,
+            SAMPLE_JSON_NODE);
+
+        AssertionError exception = assertThrows(AssertionError.class,
+            () -> assertThat(withEmptyInt, doesNotHaveEmptyValues()));
+        assertThat(exception.getMessage(), containsString(EMPTY_FIELD_ERROR));
+        assertThat(exception.getMessage(), containsString("intField"));
+    }
+
+    @Test
+    public void matcherReturnsFalseWhenObjectContainsChildWithEmptyField() {
+        ClassWithChildrenWithMultipleFields testObject =
+            new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
+        assertThat(matcher.matches(testObject), is(false));
+    }
+
+    @Test
+    public void matcherReturnsMessageWithMissingFieldsPath() {
+        ClassWithChildrenWithMultipleFields testObject =
+            new ClassWithChildrenWithMultipleFields(SAMPLE_STRING, objectMissingStringField(), SAMPLE_INT);
+        AssertionError error = assertThrows(AssertionError.class,
+            () -> assertThat(testObject, doesNotHaveEmptyValues()));
+        assertThat(error.getMessage(), containsString("objectWithFields" + FIELD_PATH_DELIMITER + "stringField"));
+    }
+
+    private WithPrimitiveFields objectMissingStringField() {
+        return new WithPrimitiveFields(null, SAMPLE_INT, SAMPLE_LIST, SAMPLE_MAP, SAMPLE_JSON_NODE);
+    }
+
+    @Test
+    public void matchesReturnsFalseWhenStringIsNull() {
+        WithPrimitiveFields nonEmptyObject = new WithPrimitiveFields(null,
+            SAMPLE_INT,
+            SAMPLE_LIST,
+            SAMPLE_MAP,
+            SAMPLE_JSON_NODE);
+        assertThat(matcher.matches(nonEmptyObject), is(false));
+    }
+
+    private static JsonNode nonEmptyJsonNode() {
+        ObjectNode node = new ObjectMapper().createObjectNode();
+        node.put("someKey", "someValue");
+        return node;
+    }
+
+    private static class WithPrimitiveFields {
+
+        private final String stringField;
+        private final Integer intField;
+        private final List<String> list;
+        private final Map<String, String> map;
+        private final JsonNode jsonNode;
+
+        public WithPrimitiveFields(String stringField, Integer intField, List<String> list,
+                                   Map<String, String> map, JsonNode jsonNode) {
+            this.stringField = stringField;
+            this.intField = intField;
+            this.list = list;
+            this.map = map;
+            this.jsonNode = jsonNode;
+        }
+
+        public String getStringField() {
+            return stringField;
+        }
+
+        public Integer getIntField() {
+            return intField;
+        }
+
+        public List<String> getList() {
+            return list;
+        }
+
+        public Map<String, String> getMap() {
+            return map;
+        }
+
+        public JsonNode getJsonNode() {
+            return jsonNode;
+        }
+    }
+
+    private static class ClassWithChildrenWithMultipleFields {
+
+        private final String someStringField;
+        private final WithPrimitiveFields objectWithFields;
+        private final Integer someIntField;
+
+        public ClassWithChildrenWithMultipleFields(String someStringField,
+                                                   WithPrimitiveFields objectWithFields, Integer someIntField) {
+            this.someStringField = someStringField;
+            this.objectWithFields = objectWithFields;
+            this.someIntField = someIntField;
+        }
+
+        public String getSomeStringField() {
+            return someStringField;
+        }
+
+        public WithPrimitiveFields getObjectWithFields() {
+            return objectWithFields;
+        }
+
+        public Integer getSomeIntField() {
+            return someIntField;
+        }
+    }
+}

--- a/src/test/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFieldsTest.java
+++ b/src/test/java/no/unit/nva/hamcrest/DoesNotHaveNullOrEmptyFieldsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+
 public class DoesNotHaveNullOrEmptyFieldsTest {
 
     public static final int SOME_BOXED_VALUE = 5;


### PR DESCRIPTION
# Desciption
Utility method for checking for empty fields when creating test objects. The previous method that we have implemented does not go in depth.

## Example:

### Usage:
```
assertThat(publication doesNotHaveEmptyValues());
```

Given a Publication with an incomplete EntityDescription the output will be 
```
Empty field found: .entityDescription.alternativeTitles,.entityDescription.contributors,.entityDescription.language,.entityDescription.mainTitle,.entityDescription.metadataSource,.entityDescription.npiSubjectHeading,.entityDescription.reference,.entityDescription.tags,
```
Given a Publication wit an incomplete File in a FileSet the output will be:
```
Empty field found: .fileSet.files[0].license.link  //(The file is  missing the link in the License)
```

### Note:
I could not find any tool that would do this. If there is one we can use the third party tool