### PR TITLE
make ignoring fields in arrays easier

### DIFF
--- a/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
+++ b/src/main/java/no/unit/nva/hamcrest/PropertyValuePair.java
@@ -24,6 +24,8 @@ public class PropertyValuePair {
     public static final String ROOT_OBJECT_PATH = "";
     public static final String LEFT_BRACE = "[";
     public static final String RIGHT_BRACE = "]";
+    public static final String ARRAY_INDEX_INDICATOR = "\\[\\d*\\]";
+    public static final String EMPTY_STRING = "";
     private final String propertyName;
     private final Object value;
     private final String fieldPath;
@@ -108,7 +110,8 @@ public class PropertyValuePair {
     }
 
     private boolean fieldIsNotIgnored(Set<String> ignoreFields, PropertyValuePair propertyValuePair) {
-        return !ignoreFields.contains(propertyValuePair.getFieldPath());
+        String genericFieldPath = propertyValuePair.getFieldPath().replaceAll(ARRAY_INDEX_INDICATOR, EMPTY_STRING);
+        return !ignoreFields.contains(genericFieldPath);
     }
 
     private String formatFieldPathInfo(String propertyName, String parentPath) {


### PR DESCRIPTION
Given the following setup, when an element of the `arrayField` is missing a value in the field `innerField` then the check `doesNotHaveEmptyValues` will return an error of the form `arrayField[X].innerField`, where "X" is the  index of the object in the list. 

With this PR, we allow to exclude the check on such specific fields by using the the command 
`assertDoesNotHaveEmptyValuesIgnoringFields(Set.of("arrayField.innerField"))`

```
public class ClassWithList {
....
 List<SampleClass> arrayField;
....
}

public class SampleClass(){

String innerField;
}
```
